### PR TITLE
Feat: "구글 로그인 개발"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Ignore application-API-KEY.yml file
+!/src/main/resources/application-API-KEY.yml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.5'
+	id 'org.springframework.boot' version '3.1.11'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -25,10 +25,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/swyg/oneului/OneuluiApplication.java
+++ b/src/main/java/com/swyg/oneului/OneuluiApplication.java
@@ -2,7 +2,9 @@ package com.swyg.oneului;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OneuluiApplication {
 

--- a/src/main/java/com/swyg/oneului/common/ApiResponse.java
+++ b/src/main/java/com/swyg/oneului/common/ApiResponse.java
@@ -1,0 +1,60 @@
+package com.swyg.oneului.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class ApiResponse<T> {
+    private static final String SUCCESS_STATUS = "success";
+    private static final String FAIL_STATUS = "fail";
+    private static final String ERROR_STATUS = "error";
+
+    private String status;
+    private T data;
+    private String message;
+
+    public ApiResponse() {
+    }
+
+    private ApiResponse(String status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ApiResponse<T> createSuccess(T data) {
+        return new ApiResponse<>(SUCCESS_STATUS, data, null);
+    }
+
+    public static ApiResponse<?> createSuccessWithNoContent() {
+        return new ApiResponse<>(SUCCESS_STATUS, null, null);
+    }
+
+    // Hibernate Validator에 의해 유효하지 않은 데이터로 인해 API 호출이 거부될때 반환
+    public static ApiResponse<?> createFail(BindingResult bindingResult) {
+        Map<String, String> errors = new HashMap<>();
+
+        List<ObjectError> allErrors = bindingResult.getAllErrors();
+        for (ObjectError error : allErrors) {
+            if (error instanceof FieldError) {
+                errors.put(((FieldError) error).getField(), error.getDefaultMessage());
+            } else {
+                errors.put( error.getObjectName(), error.getDefaultMessage());
+            }
+        }
+        return new ApiResponse<>(FAIL_STATUS, errors, null);
+    }
+
+    // 예외 발생으로 API 호출 실패시 반환
+    public static ApiResponse<?> createError(String message) {
+        return new ApiResponse<>(ERROR_STATUS, null, message);
+    }
+}

--- a/src/main/java/com/swyg/oneului/config/SecurityConfig.java
+++ b/src/main/java/com/swyg/oneului/config/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.swyg.oneului.config;
+
+import com.swyg.oneului.security.JwtAuthenticationEntryPoint;
+import com.swyg.oneului.security.TokenAuthenticationFilter;
+import com.swyg.oneului.security.oauth2.OAuth2SuccessHandler;
+import com.swyg.oneului.service.OAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    private final OAuth2UserService oAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final TokenAuthenticationFilter tokenAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> {
+            web.ignoring()
+                    .requestMatchers("/error",
+                            "/favicon.ico",
+                            "/error",
+                            "/swagger-ui/**",
+                            "/swagger-resources/**",
+                            "/v3/api-docs/**");
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) // csrf 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 기본 login form 비활성화
+                .logout(AbstractHttpConfigurer::disable) // 기본 logout 비활성화
+                .headers(headersConfigurer -> {
+                    headersConfigurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin);
+                })
+                .sessionManagement(sessionManagementConfigurer -> {
+                    sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS); // 세션 사용하지 않음
+                })
+                .authorizeHttpRequests(matcherRegistry -> {
+                    matcherRegistry
+                            .requestMatchers("/", "/auth/success").permitAll()
+                            .requestMatchers(PathRequest.toH2Console()).permitAll()
+                            .anyRequest().authenticated();
+                })
+                .oauth2Login(oAuth2LoginConfigurer -> {
+                    oAuth2LoginConfigurer
+                            .userInfoEndpoint(userInfoEndpointConfig -> {
+                                userInfoEndpointConfig.userService(oAuth2UserService);
+                            })
+                            .successHandler(oAuth2SuccessHandler);
+                })
+                .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+//                .addFilterBefore(new TokenExceptionFilter(), tokenAuthenticationFilter.getClass())
+                .exceptionHandling(exceptionHandlingConfigurer -> {
+                    exceptionHandlingConfigurer
+                            .authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                });
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/swyg/oneului/controller/AuthController.java
+++ b/src/main/java/com/swyg/oneului/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.swyg.oneului.controller;
+
+import com.swyg.oneului.common.ApiResponse;
+import com.swyg.oneului.dto.MemberDTO;
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+    private final MemberService memberService;
+
+    @GetMapping("/success")
+    public ResponseEntity<ApiResponse<?>> getSuccessResponseWithAccessToken(
+            @RequestParam(name = "accessToken") String accessToken,
+            @RequestParam(name = "loginId") String loginId) {
+
+        Member loginedMember = memberService.findMemberByLoginId(loginId);
+        MemberDTO memberDTO = MemberDTO.of(loginedMember);
+
+        return ResponseEntity.status(HttpStatus.OK).header("accessToken", accessToken).body(ApiResponse.createSuccess(memberDTO));
+    }
+
+    @GetMapping("/after-login")
+    public String getTextAfterLogin() {
+        return "SUCCESS AUTHENTICATION";
+    }
+}

--- a/src/main/java/com/swyg/oneului/controller/advice/ExceptionResponseHandler.java
+++ b/src/main/java/com/swyg/oneului/controller/advice/ExceptionResponseHandler.java
@@ -1,0 +1,34 @@
+package com.swyg.oneului.controller.advice;
+
+import com.swyg.oneului.common.ApiResponse;
+import com.swyg.oneului.exception.TokenException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionResponseHandler {
+    @ExceptionHandler(SignatureException.class)
+    public ResponseEntity<ApiResponse<?>> handleSignatureException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.createError("토큰이 유효하지 않습니다."));
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity<ApiResponse<?>> handleMalformedJwtException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.createError("올바르지 않은 토큰입니다."));
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ApiResponse<?>> handleExpiredJwtException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.createError("토큰이 만료되었습니다. 다시 로그인해주세요."));
+    }
+
+    @ExceptionHandler(TokenException.class)
+    public ResponseEntity<ApiResponse<?>> handleTokenException(TokenException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.createError(e.getMessage()));
+    }
+}

--- a/src/main/java/com/swyg/oneului/dto/MemberDTO.java
+++ b/src/main/java/com/swyg/oneului/dto/MemberDTO.java
@@ -1,0 +1,36 @@
+package com.swyg.oneului.dto;
+
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.model.MemberRole;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class MemberDTO {
+    private Long userId;
+    private String email;
+    private String name;
+    private MemberRole role;
+
+    public MemberDTO() {
+    }
+
+    @Builder
+    public MemberDTO(Long userId, String email, String name, MemberRole role) {
+        this.userId = userId;
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
+
+    public static MemberDTO of(Member member) {
+        return MemberDTO.builder()
+                .userId(member.getUserId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/swyg/oneului/exception/TokenException.java
+++ b/src/main/java/com/swyg/oneului/exception/TokenException.java
@@ -1,0 +1,15 @@
+package com.swyg.oneului.exception;
+
+public class TokenException extends RuntimeException {
+    public TokenException() {
+        super();
+    }
+
+    public TokenException(String message) {
+        super(message);
+    }
+
+    public TokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/swyg/oneului/model/BaseEntity.java
+++ b/src/main/java/com/swyg/oneului/model/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.swyg.oneului.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/com/swyg/oneului/model/Member.java
+++ b/src/main/java/com/swyg/oneului/model/Member.java
@@ -1,0 +1,54 @@
+package com.swyg.oneului.model;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Entity
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long userId;
+    private String email;
+    private String name;
+    private String loginId;
+    private String provider;
+    private String providerId;
+    private String refreshToken;
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    public Member() {
+    }
+
+    @Builder
+    public Member(Long userId, String email, String name, String loginId, String provider, String providerId, String refreshToken, MemberRole role) {
+        this.userId = userId;
+        this.email = email;
+        this.name = name;
+        this.loginId = loginId;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.refreshToken = refreshToken;
+        this.role = role;
+    }
+
+    public static Member toEntity(String provider, Map<String, Object> attributes) {
+        String email = (String) attributes.get("email");
+        String name = (String) attributes.get("name");
+        String providerId = (String) attributes.get("sub");
+        String loginId = provider + "_" + providerId;
+
+        return Member.builder()
+                .email(email)
+                .name(name)
+                .loginId(loginId)
+                .provider(provider)
+                .providerId(providerId)
+                .role(MemberRole.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/swyg/oneului/model/MemberRole.java
+++ b/src/main/java/com/swyg/oneului/model/MemberRole.java
@@ -1,0 +1,6 @@
+package com.swyg.oneului.model;
+
+public enum MemberRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/swyg/oneului/model/OAuth2Details.java
+++ b/src/main/java/com/swyg/oneului/model/OAuth2Details.java
@@ -1,0 +1,67 @@
+package com.swyg.oneului.model;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public class OAuth2Details implements OAuth2User, UserDetails {
+    private Member member;
+    private Map<String, Object> attributes;
+
+    public OAuth2Details(Member member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return member.getName();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(member.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/swyg/oneului/model/TokenHeader.java
+++ b/src/main/java/com/swyg/oneului/model/TokenHeader.java
@@ -1,0 +1,15 @@
+package com.swyg.oneului.model;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenHeader {
+    AUTHORIZATION("Authorization"),
+    TOKEN_PREFIX("Bearer ");
+
+    private final String value;
+
+    TokenHeader(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/swyg/oneului/repository/MemberRepository.java
+++ b/src/main/java/com/swyg/oneului/repository/MemberRepository.java
@@ -1,0 +1,32 @@
+package com.swyg.oneului.repository;
+
+import com.swyg.oneului.model.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class MemberRepository {
+    private final EntityManager entityManager;
+
+    public Member save(Member member) {
+        entityManager.persist(member);
+        return member;
+    }
+
+    public List<Member> findMemberByLoginId(String loginId) {
+        return entityManager.createQuery("select m from Member m where m.loginId = :loginId", Member.class)
+                .setParameter("loginId", loginId)
+                .getResultList();
+    }
+
+    public void updateRefreshToken(String refreshToken, String loginId) {
+        entityManager.createQuery("update Member m set m.refreshToken = :refreshToken where m.loginId = :loginId")
+                .setParameter("refreshToken", refreshToken)
+                .setParameter("loginId", loginId)
+                .executeUpdate();
+    }
+}

--- a/src/main/java/com/swyg/oneului/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/swyg/oneului/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.swyg.oneului.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
+    }
+}

--- a/src/main/java/com/swyg/oneului/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/swyg/oneului/security/TokenAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.swyg.oneului.security;
+
+import com.swyg.oneului.model.TokenHeader;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String accessToken = resolveToken(request);
+
+            // accessToken 검증
+            if (tokenProvider.validateToken(accessToken)) {
+                setAuthentication(accessToken);
+            } else {
+                // 만료되었을 경우 accessToken 재발급
+                String loginId = tokenProvider.extractSubjectFromToken(accessToken);
+                String reissueAccessToken = tokenProvider.reissueAccessToken(loginId);
+
+                if (StringUtils.hasText(reissueAccessToken)) {
+                    setAuthentication(reissueAccessToken);
+                    response.setHeader(TokenHeader.AUTHORIZATION.getValue(), TokenHeader.TOKEN_PREFIX.getValue() + reissueAccessToken);
+                }
+            }
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(TokenHeader.AUTHORIZATION.getValue());
+        if (ObjectUtils.isEmpty(token) || !token.startsWith(TokenHeader.TOKEN_PREFIX.getValue())) {
+            return null;
+        }
+        return token.substring(TokenHeader.TOKEN_PREFIX.getValue().length());
+    }
+
+    private void setAuthentication(String accessToken) {
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/swyg/oneului/security/TokenProvider.java
+++ b/src/main/java/com/swyg/oneului/security/TokenProvider.java
@@ -1,0 +1,127 @@
+package com.swyg.oneului.security;
+
+import com.swyg.oneului.exception.TokenException;
+import com.swyg.oneului.service.TokenService;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class TokenProvider {
+    @Value("${jwt.key}")
+    private String key;
+    private SecretKey secretKey;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24;
+    private static final String KEY_ROLE = "role";
+    private final TokenService tokenService;
+
+    @PostConstruct
+    private void initSecretKey() {
+        secretKey = Keys.hmacShaKeyFor(key.getBytes());
+    }
+
+    public String generateAccessToken(Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+    public void generateRefreshToken(Authentication authentication) {
+        String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
+        String loginId = authentication.getName();
+        tokenService.updateRefreshToken(refreshToken, loginId);
+    }
+
+    private String generateToken(Authentication authentication, long expireTime) {
+        Date currentDate = new Date();
+        Date expiredDate = new Date(currentDate.getTime() + expireTime);
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(KEY_ROLE, authorities)
+                .setIssuedAt(currentDate)
+                .setExpiration(expiredDate)
+                .signWith(secretKey, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
+
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (MalformedJwtException e) {
+            throw new TokenException("올바르지 않은 토큰입니다.");
+        } catch (SignatureException e) {
+            throw new TokenException("토큰이 유효하지 않습니다.");
+        } catch (SecurityException e) {
+            throw new TokenException("인증 과정 중 오류가 발생했습니다. 다시 로그인해주세요.");
+        }
+    }
+
+    private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+        return Collections.singletonList(new SimpleGrantedAuthority(
+                claims.get(KEY_ROLE).toString()
+        ));
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().after(new Date());
+    }
+
+    public String reissueAccessToken(String loginId) {
+        if (StringUtils.hasText(loginId)) {
+            String refreshToken = tokenService.findMemberRefreshTokenByLoginId(loginId);
+
+            if (validateToken(refreshToken)) {
+                return generateAccessToken(getAuthentication(refreshToken));
+            }
+        }
+        throw new TokenException("토큰이 만료되었습니다. 다시 로그인해주세요.");
+    }
+
+    public String extractSubjectFromToken(String accessToken) {
+        if (StringUtils.hasText(accessToken)) {
+            return parseClaims(accessToken).getSubject();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swyg/oneului/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyg/oneului/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,46 @@
+package com.swyg.oneului.security.oauth2;
+
+import com.swyg.oneului.security.TokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.misc.MultiMap;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+    private final TokenProvider tokenProvider;
+    private static final String SUCCESS_REDIRECT_URI = "/auth/success";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        // AccessToken, RefreshToken 발급
+        String accessToken = tokenProvider.generateAccessToken(authentication);
+        String loginId = authentication.getName();
+        tokenProvider.generateRefreshToken(authentication);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("accessToken", accessToken);
+        params.add("loginId", loginId);
+
+        // 토큰 전달을 위한 리다이렉트
+        String redirectUrl = ServletUriComponentsBuilder
+                .fromUriString(SUCCESS_REDIRECT_URI)
+                .queryParams(params)
+                .build()
+                .toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/swyg/oneului/service/MemberService.java
+++ b/src/main/java/com/swyg/oneului/service/MemberService.java
@@ -1,0 +1,24 @@
+package com.swyg.oneului.service;
+
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member findMemberByLoginId(String loginId) {
+        List<Member> members = memberRepository.findMemberByLoginId(loginId);
+        if (!members.isEmpty()) {
+            return members.get(0);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swyg/oneului/service/OAuth2UserService.java
+++ b/src/main/java/com/swyg/oneului/service/OAuth2UserService.java
@@ -1,0 +1,40 @@
+package com.swyg.oneului.service;
+
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.model.OAuth2Details;
+import com.swyg.oneului.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class OAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        Member member = findUserByLoginIdOrSaveIfNotFound(Member.toEntity(provider, oAuth2User.getAttributes()));
+
+        return new OAuth2Details(member, oAuth2User.getAttributes());
+    }
+
+    private Member findUserByLoginIdOrSaveIfNotFound(Member member) {
+        List<Member> members = memberRepository.findMemberByLoginId(member.getLoginId());
+        if (members.isEmpty()) {
+            return memberRepository.save(member);
+        }
+        return members.get(0);
+    }
+}

--- a/src/main/java/com/swyg/oneului/service/TokenService.java
+++ b/src/main/java/com/swyg/oneului/service/TokenService.java
@@ -1,0 +1,29 @@
+package com.swyg.oneului.service;
+
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TokenService {
+    private final MemberRepository memberRepository;
+
+    public String findMemberRefreshTokenByLoginId(String loginId) {
+        List<Member> members = memberRepository.findMemberByLoginId(loginId);
+        if (!members.isEmpty()) {
+            return members.get(0).getRefreshToken();
+        }
+        return null;
+    }
+
+    @Transactional
+    public void updateRefreshToken(String refreshToken, String loginId) {
+        memberRepository.updateRefreshToken(refreshToken, loginId);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=oneului

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  profiles:
+    include:
+      - API-KEY
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${api.google.client-id}
+            client-secret: ${api.google.client-secret}
+            scope:
+              - email
+              - profile
+jwt:
+  key: ${api.jwt.key}


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
- 구글 로그인을 위한 의존성 추가 및 yml 설정
- Security Exception을 핸들러로 관리할 수 있도록 분리
- Token을 인증하는 과정에서 발생하는 Exception을 하나로 묶어서 처리
- Token Header 관리를 위한 enum 클래스 생성
- Access Token 만료 이후 Refresh Token으로 재발급 할 수 있도록 추가
- 그 외 기본적인 기능 구현

## 기타사항