### PR TITLE
Fix: apply Spring Data JPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 # Ignore application-API-KEY.yml file
 application-API-KEY.yml
+application-dev.yml

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swyg/oneului/controller/SurveyController.java
+++ b/src/main/java/com/swyg/oneului/controller/SurveyController.java
@@ -22,7 +22,7 @@ public class SurveyController implements SurveyControllerDoc {
 
     @GetMapping("/options")
     public ResponseEntity<CommonApiResponse<List<SurveyDTO>>> getAllSurveys() {
-        List<Survey> surveys = surveyService.findAllSurveys();
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.createSuccess(SurveyDTO.listOf(surveys)));
+//        List<Survey> surveys = surveyService.findAllSurveys();
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.createSuccess(SurveyDTO.listOf(null)));
     }
 }

--- a/src/main/java/com/swyg/oneului/dto/MemberDTO.java
+++ b/src/main/java/com/swyg/oneului/dto/MemberDTO.java
@@ -41,7 +41,7 @@ public class MemberDTO {
 
     public static MemberDTO of(Member member) {
         MemberDTO memberDTO = MemberDTO.builder()
-                .userId(member.getUserId())
+                .userId(member.getMemberId())
                 .email(member.getEmail())
                 .name(member.getName())
                 .introduction(member.getIntroduction())

--- a/src/main/java/com/swyg/oneului/model/Member.java
+++ b/src/main/java/com/swyg/oneului/model/Member.java
@@ -4,26 +4,37 @@ import com.swyg.oneului.dto.MemberDTO;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
 @Getter
 @Entity
+@NoArgsConstructor
 public class Member extends BaseEntity {
     // TODO loginId가 두 번 들어왔을 때, Exception 처리해야함
     // TODO RefreshToken 캐시로 변경 예정
     @Id
-    @GeneratedValue
-    private Long userId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
     private String email;
+
     private String name;
+
     private String introduction;
+
     private String backgroundColor;
+
     @Column(unique = true)
     private String loginId;
+
     private String provider;
+
     private String providerId;
+
     private String refreshToken;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
@@ -31,12 +42,9 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "survey_id")
     private Survey survey;
 
-    public Member() {
-    }
-
     @Builder
-    public Member(Long userId, String email, String name, String introduction, String backgroundColor, String loginId, String provider, String providerId, String refreshToken, MemberRole role, Survey survey) {
-        this.userId = userId;
+    public Member(Long memberId, String email, String name, String introduction, String backgroundColor, String loginId, String provider, String providerId, String refreshToken, MemberRole role, Survey survey) {
+        this.memberId = memberId;
         this.email = email;
         this.name = name;
         this.introduction = introduction;
@@ -79,7 +87,7 @@ public class Member extends BaseEntity {
 
     public static Member of(MemberDTO memberDTO) {
         return Member.builder()
-                .userId(memberDTO.getUserId())
+                .memberId(memberDTO.getUserId())
                 .email(memberDTO.getEmail())
                 .name(memberDTO.getName())
                 .introduction(memberDTO.getIntroduction())

--- a/src/main/java/com/swyg/oneului/model/Survey.java
+++ b/src/main/java/com/swyg/oneului/model/Survey.java
@@ -1,25 +1,26 @@
 package com.swyg.oneului.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Entity
+@NoArgsConstructor
 public class Survey extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long surveyId;
-    private String option;
-    private int weight;
 
-    public Survey() {
-    }
+    @Column(name = "options") // mysql 예약어
+    private String option;
+
+    @Column(name = "weights")
+    private int weight; // mysql 예약어
 
     @Builder
     public Survey(Long surveyId, String option, int weight) {

--- a/src/main/java/com/swyg/oneului/repository/MemberRepository.java
+++ b/src/main/java/com/swyg/oneului/repository/MemberRepository.java
@@ -1,32 +1,18 @@
 package com.swyg.oneului.repository;
 
 import com.swyg.oneului.model.Member;
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@RequiredArgsConstructor
 @Repository
-public class MemberRepository {
-    private final EntityManager entityManager;
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    public Member save(Member member) {
-        entityManager.persist(member);
-        return member;
-    }
+    List<Member> findMemberByLoginId(String loginId);
 
-    public List<Member> findMemberByLoginId(String loginId) {
-        return entityManager.createQuery("select m from Member m left join m.survey where m.loginId = :loginId", Member.class)
-                .setParameter("loginId", loginId)
-                .getResultList();
-    }
-
-    public void updateRefreshToken(String refreshToken, String loginId) {
-        entityManager.createQuery("update Member m set m.refreshToken = :refreshToken where m.loginId = :loginId")
-                .setParameter("refreshToken", refreshToken)
-                .setParameter("loginId", loginId)
-                .executeUpdate();
-    }
+    @Query("update Member m set m.refreshToken = :refreshToken where m.loginId = :loginId")
+    void updateRefreshToken(@Param("refreshToken") String refreshToken, @Param("loginId") String loginId);
 }

--- a/src/main/java/com/swyg/oneului/repository/SurveyRepository.java
+++ b/src/main/java/com/swyg/oneului/repository/SurveyRepository.java
@@ -1,32 +1,16 @@
 package com.swyg.oneului.repository;
 
 import com.swyg.oneului.model.Survey;
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@RequiredArgsConstructor
 @Repository
-public class SurveyRepository {
-    private final EntityManager entityManager;
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
-    public void save(Survey survey) {
-        entityManager.persist(survey);
-    }
+    Optional<Survey> findSurveyBySurveyId(Long surveyId);
 
-    public Optional<Survey> findSurveyBySurveyId(Long surveyId) {
-        return entityManager.createQuery("select s from Survey s where s.surveyId = :surveyId", Survey.class)
-                .setParameter("surveyId", surveyId)
-                .getResultList()
-                .stream()
-                .findFirst();
-    }
-
-    public List<Survey> findAllSurveys() {
-        return entityManager.createQuery("select s from Survey s", Survey.class)
-                .getResultList();
-    }
+    List<Survey> findAll();
 }

--- a/src/main/java/com/swyg/oneului/security/TokenProvider.java
+++ b/src/main/java/com/swyg/oneului/security/TokenProvider.java
@@ -46,7 +46,7 @@ public class TokenProvider {
     public void generateRefreshToken(Authentication authentication) {
         String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
         String loginId = authentication.getName();
-        tokenService.updateRefreshToken(refreshToken, loginId);
+//        tokenService.updateRefreshToken(refreshToken, loginId);
     }
 
     private String generateToken(Authentication authentication, long expireTime) {

--- a/src/main/java/com/swyg/oneului/service/SurveyService.java
+++ b/src/main/java/com/swyg/oneului/service/SurveyService.java
@@ -18,9 +18,7 @@ public class SurveyService {
     @Transactional
     public void initSurveyOptions() {
         List<Survey> surveys = Survey.initSurveyOptions();
-        for (Survey survey : surveys) {
-            surveyRepository.save(survey);
-        }
+        surveyRepository.saveAll(surveys);
     }
 
     public Survey findSurveyBySurveyId(Long surveyId) {
@@ -29,6 +27,6 @@ public class SurveyService {
     }
 
     public List<Survey> findAllSurveys() {
-        return surveyRepository.findAllSurveys();
+        return surveyRepository.findAll();
     }
 }


### PR DESCRIPTION
## Database 벤더 변경에 따른 코드 수정


### 목적
데이터베이스 벤더를 변경합니다. H2 to Mysql

### 내용
#### 1. 개발 RDS 서버 추가
  - 별도로 공유 드리겠습니다.
  
#### 2. 개발용 프로퍼티 파일 추가 (application-dev.yml)
  - 별도로 공유 드리겠습니다.

#### 3. Member, Survey 클래스의 기본키 매핑전략 추가
  - JPA를 사용하면 기본키 매핑 전략을 명시해주어야 합니다.
  - 각 밴더마다 기본키 생성전략이 다른데요, 대표적으로 MySQL: auto-increment, Oracle: sequence, PostgreSQL: BIGSERIAL or auto-increment 등이 있습니다. JPA 사용시 PK에 해당하는 필드에 기본키 생성 전략을 명시해주셔야 합니다!
  - 자세한 내용은 다음 레퍼런스 참고하시면 좋을것 같습니다. https://www.baeldung.com/hibernate-identifiers
``` java
@Getter
@Entity
@NoArgsConstructor
public class Member extends BaseEntity {
    // TODO loginId가 두 번 들어왔을 때, Exception 처리해야함
    // TODO RefreshToken 캐시로 변경 예정
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long memberId;
```

#### 4. Member 클래스의 PK인 userId -> memberId 로 변경

#### 5. Repository 클래스 변경
- 스프링 부트 의존성에 추가해주신 `'org.springframework.boot:spring-boot-starter-data-jpa'`을 사용하면 JPA를 조금 더 쉽고 편하게 사용할 수 있습니다. Repository를 interface로 만들고 `JpaRepository<{Entity}, {PK Type}>`를 extends 하면 save(), saveAll(), delete()
등의 메서드를 직접 구현하지 않아도 사용할 수 있습니다

``` java
@Repository
public interface MemberRepository extends JpaRepository<Member, Long> {

    // save() 메서드를 직접 구현하지 않아도 Service 단에서 사용 가능합니다. JpaRepository가 상속받고 있는 CrudRepository에 해당 메서드들이 모두 구현 되어있기 때문입니다.

    List<Member> findMemberByLoginId(String loginId);

    @Query("update Member m set m.refreshToken = :refreshToken where m.loginId = :loginId")
    void updateRefreshToken(@Param("refreshToken") String refreshToken, @Param("loginId") String loginId);
}
```
- 또 쿼리를 작성하실때 `@Query` 어노테이션에 JPQL을 사용할 수 있습니다. 최근에는 해당 메서드 대신 Querydls를 사용하는 추세입니다.
- ** updateRefreshToken() 메서드 동작 확인은 하지 못했습니다! **

#### 6. 다음 에러는 무시하셔도 괜찮습니다.
![스크린샷 2024-05-04 오후 6 12 07](https://github.com/OneulUi/server/assets/96982575/c1116f01-a37f-405b-8bcd-5c097021f86e)
```
  jpa:
    hibernate:
      ddl-auto: create-drop
```

- 현재 ddl 전략을 create를 사용중이신데요, 해당 전략의 동작과정은 다음과 같습니다.
  - 하이버네이트는 외래 키 제약 조건을 삭제한 후에 테이블을 삭제하고, 그 다음에 테이블을 생성하고, 그 후에 제약 조건을 추가합니다.
- 따라서 해당 에러는 외래 키를 삭제하려고 할 때 테이블이 아직 존재하지 않은 상황에서 발생합니다. 즉, 아무 문제도 발생하지 않으며 이 오류를 무시해도 무방합니다. 다른 쿼리들은 정상적으로 작동하고 테이블은 올바르게 생성됩니다.
- 운영 환경에서는 보통 ddl 전략을 사용하지 않고 직접 테이블을 생성하고 수정하는 경우가 많기 때문에, ddl 관련 에러는 무시하셔도 좋을것 같습니다.

#### etc
어떤거 건드렸는지 기억이 안나네요 😅 혹시 궁금하신거 있으시면 편하게 연락주세요!
