### PR TITLE
Test/member case

### DIFF
--- a/src/main/java/com/swyg/oneului/repository/MemberRepository.java
+++ b/src/main/java/com/swyg/oneului/repository/MemberRepository.java
@@ -8,8 +8,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    List<Member> findMemberByLoginId(String loginId);
+    Optional<Member> findMemberByLoginId(String loginId);
 }

--- a/src/main/java/com/swyg/oneului/service/MemberService.java
+++ b/src/main/java/com/swyg/oneului/service/MemberService.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -17,12 +17,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     private Member getMemberEntityByLoginId(String loginId) {
-        List<Member> members = memberRepository.findMemberByLoginId(loginId);
-        if (!members.isEmpty()) {
-            return members.get(0);
-        }
-
-        throw new NoSuchElementException("존재하지 않는 회원입니다.");
+        Optional<Member> optionalMember = memberRepository.findMemberByLoginId(loginId);
+        return optionalMember.orElseThrow(() -> {
+            throw new NoSuchElementException("존재하지 않는 회원입니다.");
+        });
     }
 
     public Member findMemberByLoginId(String loginId) {

--- a/src/main/java/com/swyg/oneului/service/OAuth2UserService.java
+++ b/src/main/java/com/swyg/oneului/service/OAuth2UserService.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @Service
 public class OAuth2UserService extends DefaultOAuth2UserService {
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Transactional
     @Override
@@ -31,10 +31,6 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private Member findUserByLoginIdOrSaveIfNotFound(Member member) {
-        List<Member> members = memberRepository.findMemberByLoginId(member.getLoginId());
-        if (members.isEmpty()) {
-            return memberRepository.save(member);
-        }
-        return members.get(0);
+        return memberService.findMemberByLoginId(member.getLoginId());
     }
 }

--- a/src/main/java/com/swyg/oneului/util/TokenCacheLoader.java
+++ b/src/main/java/com/swyg/oneului/util/TokenCacheLoader.java
@@ -5,7 +5,6 @@ import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 
 @Component
 public class TokenCacheLoader {

--- a/src/test/java/com/swyg/oneului/service/MemberServiceTest.java
+++ b/src/test/java/com/swyg/oneului/service/MemberServiceTest.java
@@ -1,0 +1,111 @@
+package com.swyg.oneului.service;
+
+import com.swyg.oneului.model.Member;
+import com.swyg.oneului.model.MemberRole;
+import com.swyg.oneului.model.Survey;
+import com.swyg.oneului.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    public void 로그인ID로_사용자_정보를_조회한다() throws Exception {
+        // given
+        String loginId = "myLoginId";
+        Member memberFixture = creatMemberFixtureWithoutSurvey(loginId);
+        when(memberRepository.findMemberByLoginId(loginId)).thenReturn(Optional.of(memberFixture));
+
+        // when
+        Member foundMember = memberService.findMemberByLoginId(loginId);
+
+        // then
+        assertThat(memberFixture.getLoginId()).isEqualTo(foundMember.getLoginId());
+    }
+
+    @Test
+    public void 로그인ID로_조회한_사용자가_없다면_예외를_발생시킨다() throws Exception {
+        // given
+        String loginId = "myLoginId";
+
+        // when
+        when(memberRepository.findMemberByLoginId(anyString())).thenReturn(Optional.empty());
+
+        // then
+        Assertions.assertThatThrownBy(() -> memberService.findMemberByLoginId(loginId))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void 사용자가_설문정보를_등록한다() {
+        // given
+        String loginId = "myLoginId";
+        Survey survey = createSurveyFixture();
+
+        Member member = creatMemberFixtureWithoutSurvey(loginId);
+        when(memberRepository.findMemberByLoginId(loginId)).thenReturn(Optional.of(member));
+
+        // when
+        memberService.updateMemberSurvey(loginId, survey);
+
+        // then
+        assertThat(member.getSurvey().getSurveyId()).isEqualTo(survey.getSurveyId());
+    }
+
+    @Test
+    public void 사용자가_프로필을_등록한다() throws Exception {
+        // given
+        String loginId = "myLoginId";
+        String profile = "myProfile";
+        String backgroundColor = "red";
+        Member member = creatMemberFixtureWithoutSurvey(loginId);
+        Member profileInfo = Member.builder()
+                .backgroundColor(backgroundColor)
+                .introduction(profile)
+                .build();
+
+        when(memberRepository.findMemberByLoginId(loginId)).thenReturn(Optional.of(member));
+
+        // when
+        memberService.updateMemberProfile(loginId, profileInfo);
+
+        // then
+        assertThat(member.getBackgroundColor()).isEqualTo(backgroundColor);
+        assertThat(member.getIntroduction()).isEqualTo(profile);
+    }
+
+    // 설문정보, 프로필 없이 기본정보만 생성
+    private Member creatMemberFixtureWithoutSurvey(String loginId) {
+        return Member.builder()
+                .memberId(1001L)
+                .email("member@gmail.com")
+                .name("오늘의")
+                .loginId(loginId)
+                .provider("GOOGLE")
+                .role(MemberRole.USER)
+                .build();
+    }
+
+    private Survey createSurveyFixture() {
+        return new Survey(1L, "option", 1);
+    }
+}


### PR DESCRIPTION
# MemberRepository findMemberByLoginId(Stirng loginId) 변경

### 변경 전

```java
@Repository
public interface MemberRepository extends JpaRepository<Member, Long> {
    List<Member> findMemberByLoginId(String loginId);
}
```

### 변경 후 

``` java
@Repository
public interface MemberRepository extends JpaRepository<Member, Long> {
    Optional<Member> findMemberByLoginId(String loginId);
}
```

loginId에 유니크 키 제약조건을 잡아주셨습니다. 따라서 loginId로 데이터베이스 조회 쿼리를 날리게되면 하나 또는 null의 데이터가 반환됩니다.
``` java
@Column(unique = true)
private String loginId; 
```

지훈님께서도 null 처리를 위해 List를 사용해주신것 같은데요, 자바8에서 null을 처리하기 위해 Optional 클래스가 제공됩니다.
**JPA + 조회 쿼리**에서 거의 대부분의 경우 orElseThrow() 메서드를 사용해서 처리합니다!

해당 메서드는 데이터가 없는 경우 예외를 던지고 데이터가 존재하는 경우 해당 데이터를 반환할 수 있습니다.

```java
private Member getMemberEntityByLoginId(String loginId) {
    Optional<Member> optionalMember = memberRepository.findMemberByLoginId(loginId); // DB에서 조회한 데이터를 Optional로 반환합니다.

    // 데이터가 있으면 조회한 데이터를 반환하고 없는 경우 예외를 발생시킵니다.
    Member foundMember = optionalMember.orElseThrow(() -> { 
        throw new NoSuchElementException("존재하지 않는 회원입니다.");
    });

    return foundMember;
}
```

### ps

OAuth2UserService 클래스도 건드렸는데, 혹시 동작확인 한번만 부탁드립니다..! 제가 해보려고 했는데 로그인을 어떻게 하는지 모르겠어요.. ㅋㅋㅋ 화요일에 알려주세요 ㅎ

Optional 관련해서 안티패턴이 굉장히 많은데요 레퍼런스 참고해보시면 좋을것 같습니다 😃

https://homoefficio.github.io/2019/10/03/Java-Optional-%EB%B0%94%EB%A5%B4%EA%B2%8C-%EC%93%B0%EA%B8%B0/